### PR TITLE
requires python >=3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A package to take the pain out when working with the Google Search Console Search Analytics Query API."
 version = "1.0.0"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.6"
 license = {text = "GNU-3"}
 keywords = ["google", "google search console", "gsc wrapper", "google wrapper", "wrapper"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,6 @@ keywords = ["google", "google search console", "gsc wrapper", "google wrapper", 
 dependencies = [
     "oauth2client >= 4.1.3",
     "google-api-python-client >= 2.0.0",
-    "multi-args-dispatcher @ git+https://github.com/nittolese/Dispatcher",
+    "multi-args-dispatcher @ git+https://github.com/andreamoro/Dispatcher",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,6 @@ keywords = ["google", "google search console", "gsc wrapper", "google wrapper", 
 dependencies = [
     "oauth2client >= 4.1.3",
     "google-api-python-client >= 2.0.0",
-    "multi-args-dispatcher @ git+https://github.com/andreamoro/Dispatcher",
+    "multi-args-dispatcher @ git+https://github.com/nittolese/Dispatcher",
 ]
 


### PR DESCRIPTION
This project uses https://github.com/andreamoro/Dispatcher , which atm is using `match-case` statement. The problem is that this feature requires python 3.10 (https://github.com/andreamoro/Dispatcher/pull/1)